### PR TITLE
Feature/jwt

### DIFF
--- a/src/auth/auth.controller.spec.ts
+++ b/src/auth/auth.controller.spec.ts
@@ -1,17 +1,27 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { AuthController } from './auth.controller';
 import { AuthService } from './auth.service';
+import { JwtService } from '@nestjs/jwt';
 
 jest.mock('./auth.service');
 
 describe('Auth Controller', () => {
     let sut: AuthController;
     let authService: AuthService;
+    let jwtServiceMock = {
+        sign: () => 'test',
+    };
 
     beforeEach(async () => {
         const module: TestingModule = await Test.createTestingModule({
             controllers: [AuthController],
             providers: [
+                // AuthService required by Controller and JwtGuard
+                // needs JwtService
+                {
+                    provide: JwtService,
+                    useValue: jwtServiceMock,
+                },
                 AuthService, // mocked
             ],
         }).compile();
@@ -29,10 +39,25 @@ describe('Auth Controller', () => {
         jest.resetAllMocks();
     });
 
-    it('Should create a jwt', async () => {
-        const jwt = sut.getToken({ passportId: 'X' });
+    it('should be defined', () => {
+        expect(sut).toBeDefined();
+    });
 
-        expect(jwt.token).toBe('123.abc.xyz');
-        expect(jwt.jwtPayload.hashedPassportId).toBe('HASHED_TOKEN');
+    describe('Generate Token', () => {
+        it('Should create a jwt', async () => {
+            const jwt = sut.getToken({ passportId: 'X' });
+
+            expect(jwt.token).toBe('123.abc.xyz');
+            expect(jwt.jwtPayload.hashedPassportId).toBe('HASHED_TOKEN');
+        });
+    });
+
+    describe('Auth with token', () => {
+        it('should auth', async () => {
+            const response = sut.testAuth({} as any, 'user');
+
+            expect(response.auth).toBe(true);
+            expect(response.user).toBe('user');
+        });
     });
 });

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -1,6 +1,9 @@
-import { Controller, Post, Request, Body } from '@nestjs/common';
+import { Controller, Post, Request, Body, Get, UseGuards, Req } from '@nestjs/common';
 import { AuthService } from './auth.service';
 import { ApiProperty } from '@nestjs/swagger';
+import { JwtGuard } from './jwt.guard';
+import { Request as ExpressRequest } from 'express';
+import { User } from './user.decorator';
 
 export class AuthPayloadDto {
     @ApiProperty()
@@ -22,5 +25,15 @@ export class AuthController {
     @Post('token')
     getToken(@Body() payload: AuthPayloadDto): JwtTokenDto {
         return this.authService.generateToken(payload);
+    }
+
+    @Get('test')
+    @UseGuards(JwtGuard)
+    testAuth(@Request() req: ExpressRequest, @User() user: string) {
+        return {
+            auth: true,
+            'req.user': req.user,
+            user,
+        };
     }
 }

--- a/src/auth/auth.module.ts
+++ b/src/auth/auth.module.ts
@@ -4,10 +4,10 @@ import { PassportModule } from '@nestjs/passport';
 import { AuthController } from './auth.controller';
 import { AuthService } from './auth.service';
 import { TicketingModule } from '../ticketing/ticketing.module';
+import { JwtGuard } from './jwt.guard';
 
 @Module({
     imports: [
-        PassportModule,
         // loading JwtModule async to have access to process.env via ConfigService
         JwtModule.registerAsync({
             useFactory: async () => ({

--- a/src/auth/auth.service.spec.ts
+++ b/src/auth/auth.service.spec.ts
@@ -1,4 +1,3 @@
-import { Test, TestingModule } from '@nestjs/testing';
 import { AuthService } from './auth.service';
 import { HashingService } from '../ticketing/services/hashing.service';
 import { JwtService } from '@nestjs/jwt';
@@ -8,9 +7,7 @@ describe('AuthService', () => {
     const jwtService: JwtService = new JwtService({});
     const hashingService: HashingService = new HashingService();
     jest.spyOn(jwtService, 'sign').mockReturnValue('123.abc.xyz');
-    jest.spyOn(hashingService, 'hashPassportId').mockImplementation(
-        (passportId: string) => '#' + passportId,
-    );
+    jest.spyOn(hashingService, 'hashPassportId').mockImplementation((passportId: string) => '#' + passportId);
 
     // we just need one instance
     let service: AuthService = new AuthService(jwtService, hashingService);

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -5,21 +5,21 @@ import { HashingService } from '../ticketing/services/hashing.service';
 export interface IGenerateTokenPayload {
     passportId: string;
 }
+
 export interface IJwtTokenPayload {
+    hashedPassportId: string;
+}
+
+export interface IGenerateTokenResponse {
     token: string;
-    jwtPayload: {
-        hashedPassportId;
-    };
+    jwtPayload: IJwtTokenPayload;
 }
 
 @Injectable()
 export class AuthService {
-    constructor(
-        private jwtService: JwtService,
-        private hashingService: HashingService,
-    ) {}
+    constructor(private jwtService: JwtService, private hashingService: HashingService) {}
 
-    generateToken(payload: IGenerateTokenPayload): IJwtTokenPayload {
+    generateToken(payload: IGenerateTokenPayload): IGenerateTokenResponse {
         const { passportId, ...other } = payload;
         const hashedPassportId = this.hashingService.hashPassportId(passportId);
         const jwtPayload = {
@@ -30,5 +30,9 @@ export class AuthService {
             token: this.jwtService.sign(jwtPayload),
             jwtPayload,
         };
+    }
+
+    verifyToken(jwt: string): IJwtTokenPayload {
+        return this.jwtService.verify(jwt) as IJwtTokenPayload;
     }
 }

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -32,7 +32,8 @@ export class AuthService {
         };
     }
 
-    verifyToken(jwt: string): IJwtTokenPayload {
-        return this.jwtService.verify(jwt) as IJwtTokenPayload;
+    verifyToken(jwt: string): Promise<IJwtTokenPayload> {
+        // return this.jwtService.verify(jwt) as IJwtTokenPayload;
+        return this.jwtService.verifyAsync<IJwtTokenPayload>(jwt);
     }
 }

--- a/src/auth/jwt.guard.ts
+++ b/src/auth/jwt.guard.ts
@@ -1,4 +1,4 @@
-import { Injectable, CanActivate, ExecutionContext, Logger } from '@nestjs/common';
+import { Injectable, CanActivate, ExecutionContext, Logger, UnauthorizedException } from '@nestjs/common';
 import { Observable } from 'rxjs';
 import { AuthService } from './auth.service';
 
@@ -11,18 +11,33 @@ export class JwtGuard implements CanActivate {
     canActivate(context: ExecutionContext): boolean | Promise<boolean> | Observable<boolean> {
         const request = context.switchToHttp().getRequest();
 
-        const Authorization = request.get('Authorization');
-        const token = Authorization.replace('Bearer ', '');
+        const authorization = request.get('Authorization');
+        if (!authorization) {
+            throw new UnauthorizedException();
+        }
+        const token = authorization.replace('Bearer ', '');
 
-        const verified = this.authService.verifyToken(token);
-        this.logger.log('verified: ' + JSON.stringify(verified));
-
-        // put user into request in further middleware chain
-        request.user = verified;
+        const booleanPromise = this.authService
+            .verifyToken(token)
+            .then(verifiedJwt => {
+                // put user into request in further middleware chain
+                request.user = verifiedJwt;
+                return true;
+            })
+            .catch(err => {
+                this.logger.debug(
+                    'jwt verification failed with: ' +
+                        JSON.stringify({
+                            err,
+                            token,
+                        }),
+                );
+                return false;
+            });
 
         // Note that behind the scenes, when a guard returns false, the framework throws a ForbiddenException.
         // If you want to return a different error response, you should throw your own specific exception.
         // For example: throw new UnauthorizedException();
-        return !!verified;
+        return booleanPromise;
     }
 }

--- a/src/auth/jwt.guard.ts
+++ b/src/auth/jwt.guard.ts
@@ -1,0 +1,28 @@
+import { Injectable, CanActivate, ExecutionContext, Logger } from '@nestjs/common';
+import { Observable } from 'rxjs';
+import { AuthService } from './auth.service';
+
+@Injectable()
+export class JwtGuard implements CanActivate {
+    private readonly logger = new Logger(JwtGuard.name);
+
+    constructor(private readonly authService: AuthService) {}
+
+    canActivate(context: ExecutionContext): boolean | Promise<boolean> | Observable<boolean> {
+        const request = context.switchToHttp().getRequest();
+
+        const Authorization = request.get('Authorization');
+        const token = Authorization.replace('Bearer ', '');
+
+        const verified = this.authService.verifyToken(token);
+        this.logger.log('verified: ' + JSON.stringify(verified));
+
+        // put user into request in further middleware chain
+        request.user = verified;
+
+        // Note that behind the scenes, when a guard returns false, the framework throws a ForbiddenException.
+        // If you want to return a different error response, you should throw your own specific exception.
+        // For example: throw new UnauthorizedException();
+        return !!verified;
+    }
+}

--- a/src/auth/user.decorator.ts
+++ b/src/auth/user.decorator.ts
@@ -1,0 +1,19 @@
+import { createParamDecorator, ExecutionContext } from '@nestjs/common';
+
+/**
+ * a decorator as shortcut to get the user embedded from http request
+ * to use it in a controller, just add @User to the controller function parameter
+ *
+ * example:
+ * @Get('test')
+ * @UseGuards(JwtGuard)
+ *  testAuth(@User() user: IJwtTokenPayload) {
+ *      user.hashedPassportId
+ *  }
+ *
+ * see JwtGuard
+ */
+export const User = createParamDecorator((_data: unknown, ctx: ExecutionContext) => {
+    const request = ctx.switchToHttp().getRequest();
+    return request.user;
+});

--- a/test/app.e2e-spec.ts
+++ b/test/app.e2e-spec.ts
@@ -123,7 +123,7 @@ describe('End-2-End Testing', () => {
 
     describe('Auth', () => {
         it(
-            'should create jwt',
+            'should create jwt and use it',
             async () => {
                 return await request(app.getHttpServer())
                     .post('/api/v1/auth/token')
@@ -131,17 +131,26 @@ describe('End-2-End Testing', () => {
                         passportId: 'LXXXXX',
                     })
                     .expect(201)
-                    .expect(tokenResponse => {
-                        expect(tokenResponse.body.token).toBeTruthy();
+                    .expect(async tokenResponse => {
+                        const jwt = tokenResponse.body.token;
+                        expect(jwt).toBeTruthy();
                         expect(tokenResponse.body.jwtPayload.hashedPassportId).toBeTruthy();
                         // validate signature against process.env from .env.test
                         const jwtServiceUtil = new JwtService({ secret: process.env.JWT_SECRET });
-                        const verified = jwtServiceUtil.verify(tokenResponse.body.token);
+                        const verified = jwtServiceUtil.verify(jwt);
                         expect(verified).toBeTruthy();
-                        // decode jwt and check payload
-                        const decoded = jwtServiceUtil.decode(tokenResponse.body.token);
-                        expect(decoded).toBeTruthy();
-                        expect(decoded['hashedPassportId']).toBe(tokenResponse.body.jwtPayload.hashedPassportId);
+                        expect(verified.hashedPassportId).toBe(tokenResponse.body.jwtPayload.hashedPassportId);
+
+                        // use token to access secured controller
+                        return await request(app.getHttpServer())
+                            .get('/api/v1/auth/test')
+                            .auth(jwt, { type: 'bearer' })
+                            .expect(200)
+                            .expect(testResponse => {
+                                expect(testResponse.body.auth).toBe(true);
+                                expect(testResponse.body.user.hashedPassportId).toBe(verified.hashedPassportId);
+                                expect(testResponse.body.user.hashedPassportId).toBe(tokenResponse.body.jwtPayload.hashedPassportId);
+                            });
                     });
             },
             timeout,


### PR DESCRIPTION
hinzufügen einer abgesicherten Route als Beispiel / Test der JWT Authentication
benutzt einen simplen JwtGuard

> ich habe hier erstmal nicht auf die Passport Sachen gesetzt. 
> https://docs.nestjs.com/techniques/authentication#implementing-passport-jwt

Ein einfaches Lesen und verifizieren des Tokens aus dem Header fande ich für den Anfang besser.

Den User decorator habe ich gefunden damit man nicht immer den ganzen Request autowiren muss :-)