### PR TITLE
Feature/verification code

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13014,6 +13014,11 @@
             "integrity": "sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw==",
             "optional": true
         },
+        "nanoid": {
+            "version": "3.1.7",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.7.tgz",
+            "integrity": "sha512-ruOwuatdEf4BxQmZopZqhIMudQ9V83aKocr+q2Y7KasnDNvo2OgbgZBYago5hSD0tCmoSl4flIw9ytDLIVM2IQ=="
+        },
         "nanomatch": {
             "version": "1.2.13",
             "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
         "jest-config": "^25.4.0",
         "mongodb": "^3.5.6",
         "mongoose": "^5.9.10",
+        "nanoid": "^3.1.7",
         "neverthrow": "^2.2.0",
         "passport": "^0.4.1",
         "passport-jwt": "^4.0.0",

--- a/src/ticketing/controller/tickets.controller.spec.ts
+++ b/src/ticketing/controller/tickets.controller.spec.ts
@@ -28,6 +28,7 @@ describe('TicketsController', () => {
         // Mock ticket save to db
         const mockedTicket: Ticket = {
             ticketId: 'testing',
+            verificationCode: '123456abc',
             reason: 'simulation',
             startAddress: {
                 street: '',
@@ -81,6 +82,7 @@ describe('TicketsController', () => {
             const mockedTicketResponse: Ticket = {
                 ticketStatus: 'CREATED',
                 ticketId: 'unique-ticket-id',
+                verificationCode: '123456abc',
                 hashedPassportId: await hashingService.hashPassportId(ticketRequest.passportId),
                 ...ticketRequest,
             };

--- a/src/ticketing/controller/tickets.controller.ts
+++ b/src/ticketing/controller/tickets.controller.ts
@@ -89,6 +89,7 @@ export class TicketsController {
     private mapToDto(ticket: Ticket): TicketResponseDto {
         return {
             ticketId: ticket.ticketId,
+            verificationCode: ticket.verificationCode,
             ticketStatus: ticket.ticketStatus,
             validFromDateTime: ticket.validFromDateTime,
             validToDateTime: ticket.validToDateTime,

--- a/src/ticketing/controller/tickets.dto.ts
+++ b/src/ticketing/controller/tickets.dto.ts
@@ -95,6 +95,15 @@ export class TicketResponseDto implements Ticket {
     })
     hashedPassportId: string;
 
+    @ApiProperty({
+        readOnly: true,
+        minLength: 9,
+        maxLength: 9,
+        example: 'c29a07f78',
+        description: 'shortcode for verification',
+    })
+    verificationCode: string;
+
     @ApiProperty()
     @IsNotEmpty()
     reason: string;

--- a/src/ticketing/services/shortid.service.spec.ts
+++ b/src/ticketing/services/shortid.service.spec.ts
@@ -1,0 +1,14 @@
+import { ShortidService } from './shortid.service';
+
+describe('ShortidService', () => {
+    // we just need one instance
+    let service: ShortidService = new ShortidService();
+
+    it('should be defined', () => {
+        expect(service).toBeDefined();
+    });
+
+    it('should generate shortid', () => {
+        expect(service.generateShortId()).toMatch(/[0123456789abcdefghjklmnpqrstuvwxyz]{9}/);
+    });
+});

--- a/src/ticketing/services/shortid.service.ts
+++ b/src/ticketing/services/shortid.service.ts
@@ -1,0 +1,22 @@
+import { Injectable } from '@nestjs/common';
+
+import { customAlphabet as customNanoid } from 'nanoid';
+
+@Injectable()
+export class ShortidService {
+    /**
+     * use https://zelark.github.io/nano-id-cc/ to calculate collision of alphabet and size
+     */
+
+    // numbers and lowercase (without O and I)
+    private alphabet = '0123456789' + 'abcdefghjklmnpqrstuvwxyz';
+    /**
+     * Speed: 1000 IDs per hour
+     * ~46 days needed, in order to have a 1% probability of at least one collision.
+     */
+    private nanoid = customNanoid(this.alphabet, 9);
+
+    generateShortId() {
+        return this.nanoid();
+    }
+}

--- a/src/ticketing/services/tickets.schema.ts
+++ b/src/ticketing/services/tickets.schema.ts
@@ -9,6 +9,8 @@ export const ticketSchema = new mongoose.Schema(
     {
         hashedPassportId: String,
 
+        verificationCode: { type: String, unique: true },
+
         reason: String,
 
         startAddress: {

--- a/src/ticketing/ticketing.module.ts
+++ b/src/ticketing/ticketing.module.ts
@@ -4,11 +4,12 @@ import { TicketsController } from './controller/tickets.controller';
 import { ticketSchema, TICKET_MODEL_NAME } from './services/tickets.schema';
 import { TicketsService } from './services/tickets.service';
 import { CryptoModule } from '../crypto/crypto.module';
+import { ShortidService } from './services/shortid.service';
 
 @Module({
     imports: [MongooseModule.forFeature([{ name: TICKET_MODEL_NAME, schema: ticketSchema }]), CryptoModule],
     controllers: [TicketsController],
-    providers: [TicketsService],
+    providers: [TicketsService, ShortidService],
     exports: [TicketsService],
 })
 export class TicketingModule {}

--- a/test/app.e2e-spec.ts
+++ b/test/app.e2e-spec.ts
@@ -82,6 +82,7 @@ describe('End-2-End Testing', () => {
                 .expect(201)
                 .then(res => {
                     expect(res.body.hashedPassportId).toBe(hashedPassportId);
+                    expect(res.body.verificationCode).toMatch(/[0123456789abcdefghjklmnpqrstuvwxyz]{9}/);
                 });
         });
 
@@ -196,7 +197,7 @@ describe('End-2-End Testing', () => {
     );
 
     it(
-        'can not create Ticket because id is wrong',
+        'can not create Ticket because passportId is wrong',
         async () => {
             partyTicket.passportId = '';
             return await request(app.getHttpServer())


### PR DESCRIPTION
Generierung eines Verification Codes unter Benutzung von npm nanoid
siehe https://github.com/ai/nanoid

Für den Anfang würde ich einen 9 stelligen Code bestehend aus Nummern und Lowercase Buchstaben ohne o und i vorschlagen. ([0123456789abcdefghjklmnpqrstuvwxyz]{9})
Beispiel: h7zptpx9h
Collision lässt sich unter https://zelark.github.io/nano-id-cc/ wie folgt berechnen:
* mit 1000 IDs per hour ~46 days needed, in order to have a 1% probability of at least one collision.

**Die Idee eines verification Codes:**
Im Falle einer Kontrolle (durch Polizei) muss jemand das Ticket öffnen. Wenn man kein Smartphone mit QR Scanner besitzt, händische Eingabe der ID in eine Seite oder Weitergabe der ID per Telefon/Funk. Für den Fall ist eine kurze und bestehend aus eindeutigen Zeichen besser.

Noch besser wird es in Kombination mit der Telefon API als automatisierte Hotline. Hier hatte ich eine simple aber effektive Idee für die Eingabe des Codes.

**1. Eingabe der Short ID per Telefontastatur.** 
Aber wie gibt man alpha-numerische Ids ein? Ganz einfach: Per ASCII Tabelle 😆 Der Benutzer benötigt die ASCII Tabelle um das Zeichen in den Dezimal ASCII Code umzuwandeln. Anschließend gibt er die numerische Repräsentation ein. (Gleiches gilt für Eingabe Personalausweisnummer). (Neben ASCII gibt es sicherlich noch andere Ansätze wie man Buchstaben in Zahlen darstellt. Aber ASCII wäre zumindest mal ein Standard. Wenn nicht DER Standard.)

Nachteil: Die Anzahl der Zeichen die er eingeben muss verdoppelt sich. Von 9 auf 18. 

Vorteil: Aber der Benutzer ist vollkommen selbständig und benötigt keine Unterstützung von einer anderen Person. Dies wiegt den Nachteil locker wieder auf. 

Beispiel: aus dem Short code "h7zptpx9h" bilden wir zunächst das uppercase (damit die Dezimal Ascii immer zweistellig bleiben, bei kleinen Buchstaben wird es ab d dreistellig). Und bilden dann "H7ZPTPX9H" aus die ASCII Codes: 72 55 90 80 84 80 88 57 72

**2. Eingabe der Short ID per Spracherkennung mit deutschem Buchstabieralphabet**
Wenn sich die Eingabe per Telefontastatur als nicht praktikabel erweist. Könnte man die Spracherkennung (Speech-to-text) testen.

Vermutlich klappt die Erkennung eines diktierten Shortcodes besser wenn man das Buchstabieralphabet verwendet.

Nachteil: Buchstabieralphabet und vermutlich hohe Fehleranfälligkeit durch Umgebungsgeräusche, Aussprache, Dialekt etc.

Vorteil: schneller als Umrechnung in ASCII und Eingabe der langen ASCII Zahl.

Beispiel: h7zptpx9h => Heinrich Sieben Zeppelin Paula Theodor Paula Xanthippe Neun Heinrich
(Insbesondere bei Paula hätten Franken jetzt schon ein Problem ;-) )

---
Alternativen zu nanoid:
- shortid (unterstützt nur ein Alphabet von genau 64 Zeichen)
- https://hashids.org/